### PR TITLE
Add compability for older versions of MATLAB (≥R2008a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Nor is `jlcall` the first attempt to facilitate calling Julia from MATLAB. For i
 
 ### Prerequisites
 
-It goes without saying that using `jlcall` requires having both MATLAB and Julia (>=v.0.4) installed on your system. Additionally, to build the MEX function from source, you need a C++ compiler configured to work with MATLAB's `mex` function. You can ensure this is done by executing:
+It goes without saying that using `jlcall` requires having both MATLAB (>=R2008a) and Julia (>=v.0.4) installed on your system. Additionally, to build the MEX function from source, you need a C++ compiler configured to work with MATLAB's `mex` function. You can ensure this is done by executing:
 
 ```
 >> mex -setup C++

--- a/m/Jl.m
+++ b/m/Jl.m
@@ -21,7 +21,8 @@ classdef Jl
     end
 
     function p = forward_slashify(p)
-      p = strjoin(strsplit(p, filesep), '/');
+      p = regexp(p, filesep, 'split');
+      p = [sprintf('%s/', p{1:end-1}) p{end}];
     end
 
     function eval_string(expr)
@@ -61,8 +62,8 @@ classdef Jl
     end
 
     function conf = get_config_file()
-      bits = strsplit(mfilename('fullpath'), filesep);
-      conf = strjoin([bits(1:end-1), 'jlconfig.mat'], filesep);
+      mfiledir = fileparts(mfilename('fullpath'));
+      conf = [mfiledir filesep 'jlconfig.mat'];
 
       % run jlconfig if the file doesn't exist
       if exist(conf, 'file') ~= 2
@@ -72,8 +73,8 @@ classdef Jl
     end
 
     function boot = get_boot_file()
-      bits = strsplit(mfilename('fullpath'), filesep);
-      boot = strjoin([bits(1:end-2), 'jl', 'boot.jl'], filesep);
+      mfiledir = fileparts(mfilename('fullpath'));
+      boot = fullfile(mfiledir, '..', 'jl', 'boot.jl');
     end
 
     function v = read_config(nm)

--- a/m/jlbuild.m
+++ b/m/jlbuild.m
@@ -4,9 +4,8 @@ if nargin < 1
   vq = '';
 end
 
-bits = strsplit(mfilename('fullpath'), filesep);
-this_dir = strjoin(bits(1:end-1), filesep);
-conf_name = [this_dir filesep 'jlconfig.mat'];
+this_dir = fileparts(mfilename('fullpath'));
+conf_name = fullfile(this_dir, 'jlconfig.mat');
 if exist(conf_name, 'file') ~= 2
   warning([conf_name ' not found. Attempting to reconfigure...']);
   jlconfig;
@@ -14,7 +13,7 @@ end
 conf = matfile(conf_name);
 
 % build the mex file
-julia_src = [this_dir filesep '..' filesep 'src' filesep 'jlcall.cpp'];
+julia_src = fullfile(this_dir, '..', 'src', 'jlcall.cpp');
 mex_cmd = 'mex %s -largeArrayDims -O -output jlcall -outdir ''%s'' -I''%s'' -L''%s'' ''%s'' %s';
 eval(sprintf(mex_cmd, vq, this_dir, conf.julia_include_dir, conf.julia_lib_dir, julia_src, conf.lib_opt));
 

--- a/m/jlconfig.m
+++ b/m/jlconfig.m
@@ -3,12 +3,11 @@ function jlconfig(exe)
 if nargin < 1
   % try to guess the path of the julia executable
   if ispc
-    [~, o] = system('where julia');
+    [~, exe] = system('where julia');
   else
-    [~, o] = system('which julia');
+    [~, exe] = system('which julia');
   end
-  exes = strsplit(o, {'\n','\r'}, 'CollapseDelimiters', true);
-  exe = exes{1};
+  exe = strtrim(exe);
   if exist(exe, 'file') == 0
     exe = 'julia';
   end
@@ -61,8 +60,7 @@ fprintf('The Julia include directory is %s\n', julia_include_dir);
 
 % get lib dir, opts
 if ispc
-  bits = strsplit(julia_image, filesep);
-  julia_lib_dir = strjoin(bits(1:end-2), filesep);
+  julia_lib_dir = [directory(julia_image) filesep '..'];
   lib_opt = 'libjulia.dll.a';
 else
   [~, julia_lib_dir] = system(sprintf(cmd, exe, 'abspath(dirname(Libdl.dlpath("libjulia")))'));
@@ -86,7 +84,7 @@ conf.lib_opt = lib_opt;
 jlbuild;
 
 % check if this directory is on the search path
-path_dirs = strsplit(path, pathsep);
+path_dirs = regexp(path, pathsep, 'split');
 if ispc
   on_path = any(strcmpi(this_dir, path_dirs));
 else
@@ -110,8 +108,7 @@ end
 
 % directory of path
 function d = directory(p)
-  bits = strsplit(p, filesep);
-  d = strjoin(bits(1:end-1), filesep);
+  d = fileparts(p);
 end
 
 % remove leading, trailing whitespace
@@ -121,5 +118,6 @@ function str = chomp(str)
 end
 
 function str = np(str)
-  str = strjoin(strsplit(str, filesep), '/');
+  parts = regexp(str, filesep, 'split');
+  str = [sprintf('%s/', parts{1:end-1}) parts{end}];
 end


### PR DESCRIPTION
The functions `strjoin` and `strsplit` were added in MATLAB R2013a and are not available in previous version. I made use of functions that were available since MATLAB R2006a: fullfile, regexp, sprintf, strtrim.

I believe that the MATLAB code should work with R2008a and newer although I was testing on R2012b. Note that R2008a was when MATLAB introduced the `classdef` syntax.
