### PR TITLE
Add rpath to jlcall (Mac OS X)

### DIFF
--- a/m/jlbuild.m
+++ b/m/jlbuild.m
@@ -18,4 +18,9 @@ julia_src = [this_dir filesep '..' filesep 'src' filesep 'jlcall.cpp'];
 mex_cmd = 'mex %s -largeArrayDims -O -output jlcall -outdir ''%s'' -I''%s'' -L''%s'' ''%s'' %s';
 eval(sprintf(mex_cmd, vq, this_dir, conf.julia_include_dir, conf.julia_lib_dir, julia_src, conf.lib_opt));
 
+% Add rpath to the binary
+if ismac
+  system(sprintf('install_name_tool -add_rpath ''%s'' ''%s''', conf.julia_lib_dir, fullfile(this_dir, ['jlcall.' mexext])));
+end
+
 end


### PR DESCRIPTION
On Mac OS X (10.11.2) I could sucessfully compile `jlcall` but not run it due to the following error:

```
Invalid MEX-file '/.../jlcall/m/jlcall.mexmaci64':
dlopen(/.../jlcall/m/jlcall.mexmaci64, 1): Library not loaded: @rpath/libjulia.dylib
  Referenced from: /.../jlcall/m/jlcall.mexmaci64
  Reason: image not found

Error in Jl/get_mex_handle (line 58)
      jlcall('', Jl.julia_home, Jl.julia_image);
```

The solution of compiling with `-rpath` in #7 doesn't work under OS X and even setting the environment variables DYLD_LIBRARY_PATH and/or LD_RUN_PATH also doesn't appear to work. The solution I have provided is what [is used by homebrew-julia](https://github.com/staticfloat/homebrew-julia/blob/master/julia.rb#L169) so it should work on other OS X versions.
