### PR TITLE
Fix example

### DIFF
--- a/examples/lmdif.jl
+++ b/examples/lmdif.jl
@@ -1,6 +1,6 @@
-using Optim
+using LsqFit
 using Calculus
 
 # a simple wrapper for Levenberg-Marquardt with finite differencing for the
 # Jacobian
-lmdif(f, x0; show_trace::Bool=false) = Optim.levenberg_marquardt(f, jacobian(f), x0, show_trace=show_trace)
+lmdif(f, x0; show_trace::Bool=false) = LsqFit.levenberg_marquardt(f, jacobian(f), x0, show_trace=show_trace)


### PR DESCRIPTION
Levenberg-Marquardt algorithm has been moved into LsqFit starting with Optim.jl 0.9.0.