### PR TITLE
Using libjulia.dll.a fullpath, to support MinGW-64

### DIFF
--- a/jl.m
+++ b/jl.m
@@ -235,7 +235,8 @@ classdef jl
 
             % set ldlibs
             if ispc
-                ldlibs = [ 'lib' jl.get('lib_base') '.dll.a' ];
+                % get full path to .dll.a file
+                ldlibs = fullfile(jl.get('lib_dir'), [ 'lib' jl.get('lib_base') '.dll.a' ]);
             else
                 ldlibs = [ '-l' jl.get('lib_base') ' -ldl' ];
             end


### PR DESCRIPTION
This is a simple change that allows support for MinGW-64.  At time of PR, this change has not been tested against MSVC.  I tested it against MinGW-64 on Win10, x86-64, Matlab R2016b (64bit).  

It should 'just work', for MSVC but needs to be tested.  Full output below from MinGW test:
```
>> jl.config()
         build_cflags: '-O -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia" -DJULIA_ENABLE_THREADING'
        build_ldflags: '-L"C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib"'
         build_ldlibs: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib\libjulia.dll.a'
            build_src: 'C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.cpp'
              inc_dir: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia'
             is_debug: 'false'
            julia_bin: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\julia.exe'
           julia_home: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\bin'
             lib_base: 'julia'
              lib_dir: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib'
             lib_path: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\libjulia.dll'
            sys_image: 'C:\Users\stddev\AppData\Local\Julia-0.6.0\lib\julia\sys.dll'
    threading_enabled: 'true'

C:\Users\stddev\src\standarddeviant\mexjulia is not on the MATLAB path. Adding it and saving...
The mex command to be executed:
mex -v -largeArrayDims -L"C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib" -outdir "C:\Users\stddev\src\standarddeviant\mexjulia" -O -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia" -DJULIA_ENABLE_THREADING C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.cpp C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib\libjulia.dll.a
Verbose mode is on.
... Looking for compiler 'MinGW64 Compiler (C++)' ...
... Looking for environment variable 'MW_MINGW64_LOC' ...Yes ('C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset').
... Looking for file 'C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++.exe' ...Yes.
... Looking for folder 'C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset' ...Yes.
Found installed compiler 'MinGW64 Compiler (C++)'.
Set PATH = C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin;C:\Program Files\MATLAB\R2016b\extern\include\win64;C:\Program Files\MATLAB\R2016b\extern\include;C:\Program Files\MATLAB\R2016b\simulink\include;C:\Program Files\MATLAB\R2016b\lib\win64;C:\MinGW\bin;C:\Program Files\Docker\Docker\Resources\bin;C:\Anaconda3\Scripts;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Windows\System32;C:\Users\stddev\Downloads\ffmpeg-20170116-e664730-win64-static\bin;C:\Program Files (x86)\Gow\bin;C:\Anaconda3;C:\Program Files\Git\bin;C:\Program Files (x86)\Java\jre1.8.0_101\bin;C:\Program Files (x86)\SSH Communications Security\SSH Secure Shell;C:\Program Files\TortoiseSVN\bin;C:\Program Files (x86)\sox-14-4-2;C:\Users\stddev\.babun;C:\Users\stddev\AppData\Local\Julia-0.5.0\bin;C:\Users\stddev\AppData\Local\Microsoft\WindowsApps;C:\Users\stddev\AppData\Local\atom\bin;C:\Program Files (x86)\Meld
Set INCLUDE = C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\include;
Set LIB = C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\lib;;
Set MW_TARGET_ARCH = win64;
Set LIBPATH = C:\Program Files\MATLAB\R2016b\extern\lib\win64;
Options file details
-------------------------------------------------------------------
	Compiler location: C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset
	Options file: C:\Users\stddev\AppData\Roaming\MathWorks\MATLAB\R2016b\mex_C++_win64.xml
	CMDLINE2 : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++ -m64 -Wl,--no-undefined -shared -s -Wl,"C:\Program Files\MATLAB\R2016b/extern/lib/win64/mingw64/exportsmexfileversion.def" C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.obj C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\cpp_mexapi_version.obj   C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib\libjulia.dll.a  -LC:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib   -L"C:\Program Files\MATLAB\R2016b\extern\lib\win64\mingw64" -llibmx -llibmex -llibmat -lm -llibmwlapack -llibmwblas -o C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.mexw64
	CXX : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++
	COMPILER : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++
	DEFINES : -DJULIA_ENABLE_THREADING   -m64 -DMATLAB_MEX_FILE 
	MATLABMEX : -DMATLAB_MEX_FILE 
	CXXFLAGS : -fexceptions -fno-omit-frame-pointer -std=c++11
	INCLUDE : -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia"  -I"C:\Program Files\MATLAB\R2016b/extern/include" -I"C:\Program Files\MATLAB\R2016b/simulink/include"
	CXXOPTIMFLAGS : -O -DNDEBUG
	CXXDEBUGFLAGS : -g
	LDXX : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++
	LINKER : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++
	LDFLAGS : -m64 -Wl,--no-undefined
	LDTYPE : -shared
	LINKEXPORT : -Wl,"C:\Program Files\MATLAB\R2016b/extern/lib/win64/mingw64/mexFunction.def"
	LINKEXPORTVER : -Wl,"C:\Program Files\MATLAB\R2016b/extern/lib/win64/mingw64/exportsmexfileversion.def"
	LIBLOC : C:\Program Files\MATLAB\R2016b\extern\lib\win64\mingw64
	LINKLIBS : C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib\libjulia.dll.a  -LC:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib   -L"C:\Program Files\MATLAB\R2016b\extern\lib\win64\mingw64" -llibmx -llibmex -llibmat -lm -llibmwlapack -llibmwblas
	LDOPTIMFLAGS : -s
	LDDEBUGFLAGS : -g
	OBJEXT : .obj
	LDEXT : .mexw64
	SETENV : set COMPILER=g++ 
				set COMPFLAGS=-c -fexceptions -fno-omit-frame-pointer -std=c++11 -DJULIA_ENABLE_THREADING   -m64 -DMATLAB_MEX_FILE  -DMATLAB_MEX_FILE  
				set OPTIMFLAGS=-O -DNDEBUG 
				set DEBUGFLAGS=-g 
				set LINKER=g++ 
				set LINKFLAGS=-m64 -Wl,--no-undefined -shared C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib\libjulia.dll.a  -LC:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib   -L"C:\Program Files\MATLAB\R2016b\extern\lib\win64\mingw64" -llibmx -llibmex -llibmat -lm -llibmwlapack -llibmwblas -Wl,"C:\Program Files\MATLAB\R2016b/extern/lib/win64/mingw64/mexFunction.def" 
				set LINKDEBUGFLAGS=-g
				set NAME_OUTPUT= -o "%OUTDIR%%MEX_NAME%%MEX_EXT%"
	MINGWROOT : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset
	MATLABROOT : C:\Program Files\MATLAB\R2016b
	ARCH : win64
	SRC : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.cpp;"C:\Program Files\MATLAB\R2016b\extern\version\cpp_mexapi_version.cpp"
	OBJ : C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.obj;C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\cpp_mexapi_version.obj
	OBJS : C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.obj C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\cpp_mexapi_version.obj 
	SRCROOT : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia
	DEF : C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.def
	EXP : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.exp
	LIB : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.lib
	EXE : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.mexw64
	ILK : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.ilk
	MANIFEST : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.mexw64.manifest
	TEMPNAME : C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia
	EXEDIR : C:\Users\stddev\src\standarddeviant\mexjulia\
	EXENAME : mexjulia
	OPTIM : -O -DNDEBUG
	LINKOPTIM : -s
	CMDLINE1_0 : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++ -c -DJULIA_ENABLE_THREADING   -m64 -DMATLAB_MEX_FILE  -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia"  -I"C:\Program Files\MATLAB\R2016b/extern/include" -I"C:\Program Files\MATLAB\R2016b/simulink/include" -fexceptions -fno-omit-frame-pointer -std=c++11 -O -DNDEBUG C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.cpp -o C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.obj
	CMDLINE1_1 : C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++ -c -DJULIA_ENABLE_THREADING   -m64 -DMATLAB_MEX_FILE  -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia"  -I"C:\Program Files\MATLAB\R2016b/extern/include" -I"C:\Program Files\MATLAB\R2016b/simulink/include" -fexceptions -fno-omit-frame-pointer -std=c++11 -O -DNDEBUG "C:\Program Files\MATLAB\R2016b\extern\version\cpp_mexapi_version.cpp" -o C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\cpp_mexapi_version.obj
-------------------------------------------------------------------
Building with 'MinGW64 Compiler (C++)'.
C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++ -c -DJULIA_ENABLE_THREADING   -m64 -DMATLAB_MEX_FILE  -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia"  -I"C:\Program Files\MATLAB\R2016b/extern/include" -I"C:\Program Files\MATLAB\R2016b/simulink/include" -fexceptions -fno-omit-frame-pointer -std=c++11 -O -DNDEBUG C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.cpp -o C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.obj
C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++ -c -DJULIA_ENABLE_THREADING   -m64 -DMATLAB_MEX_FILE  -I"C:\Users\stddev\AppData\Local\Julia-0.6.0\include\julia"  -I"C:\Program Files\MATLAB\R2016b/extern/include" -I"C:\Program Files\MATLAB\R2016b/simulink/include" -fexceptions -fno-omit-frame-pointer -std=c++11 -O -DNDEBUG "C:\Program Files\MATLAB\R2016b\extern\version\cpp_mexapi_version.cpp" -o C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\cpp_mexapi_version.obj
C:\ProgramData\MATLAB\SupportPackages\R2016b\3P.instrset\mingw_492.instrset\bin\g++ -m64 -Wl,--no-undefined -shared -s -Wl,"C:\Program Files\MATLAB\R2016b/extern/lib/win64/mingw64/exportsmexfileversion.def" C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\mexjulia.obj C:\Users\stddev\AppData\Local\Temp\mex_10347881940578_11232\cpp_mexapi_version.obj   C:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib\libjulia.dll.a  -LC:\Users\stddev\AppData\Local\Julia-0.6.0\bin\..\lib   -L"C:\Program Files\MATLAB\R2016b\extern\lib\win64\mingw64" -llibmx -llibmex -llibmat -lm -llibmwlapack -llibmwblas -o C:\Users\stddev\src\standarddeviant\mexjulia\mexjulia.mexw64
MEX completed successfully.
```